### PR TITLE
Fix comment in code example of Parameters utility type

### DIFF
--- a/pages/Utility Types.md
+++ b/pages/Utility Types.md
@@ -180,7 +180,7 @@ declare function f1(arg: { a: number, b: string }): void
 type T0 = Parameters<() => string>;  // []
 type T1 = Parameters<(s: string) => void>;  // [string]
 type T2 = Parameters<(<T>(arg: T) => T)>;  // [unknown]
-type T4 = Parameters<typeof f1>;  // { a: number, b: string }
+type T4 = Parameters<typeof f1>;  // [{ a: number, b: string }]
 type T5 = Parameters<any>;  // unknown[]
 type T6 = Parameters<never>;  // any
 type T7 = Parameters<string>;  // Error


### PR DESCRIPTION
In the Parameters<T> examples, the type T4 comment is missing brackets.
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
